### PR TITLE
Tabs 

### DIFF
--- a/Examples/Examples_Tabs.vue
+++ b/Examples/Examples_Tabs.vue
@@ -1,14 +1,16 @@
 <template>
     <div>
     <iv-tabs>
-        <iv-tab tabName="Tab 1" :selected="true">
-            <h1>Display Content 1</h1>
+        <iv-tab tabName="Tab 1" tabIndex="1" :selected="true">
+            <h2>Display Content 1</h2>
         </iv-tab>
-        <iv-tab tabName="Tab 2">                      
-            <h1>Display Content 2</h1>
+
+        <iv-tab tabName="Tab 2" tabIndex="2">                      
+            <h2>Display Content 2</h2>
         </iv-tab>
-        <iv-tab tabName="Tab 3">
-            <h1>Display Content 3</h1>
+
+        <iv-tab tabName="Tab 3" tabIndex="3">
+            <h2>Display Content 3</h2>
         </iv-tab>
     </iv-tabs>
     </div>

--- a/src/components/Tabs/Tab.vue
+++ b/src/components/Tabs/Tab.vue
@@ -7,6 +7,8 @@ export default {
     props: {
         tabName: {type: String,
         required: true },
+        tabIndex: {Type: Number,
+        required: true },
         selected: {type: Boolean,
         default: false}
     },

--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -1,10 +1,6 @@
 <template>
     <div class="tabContainer">
-            <ul>
-                <li v-for="(tab,index) in tabs" :key="index" :class="{ 'is-active': tab.isActive }">
-                    <a :href="tab.href" @click="selectTab(tab)">{{ tab.tabName}}</a>
-                </li>
-            </ul>
+            <toggle-advance :modes="tabNames" @toggleswitched="selectTab" />
             <div class="tabDetails">
             <slot></slot>
             </div>
@@ -12,41 +8,40 @@
 
 </template>
 <script>
+import ToggleAdvance from '../ToggleAdvance';
 export default {
     name: "iv-tabs",
-
+    components:{
+      ToggleAdvance
+    },
     data() {
         return {
           tabs: [],
           tabActived:"Tab 1 is opened",
-          initialIndex: 1,
+          initialIndex: 0
           };
     },
-    
-    created() {
-      
-        this.tabs = this.$children;
-        
+    mounted() {
+      this.tabs = this.$children.filter(mtab => mtab.$options._componentTag != 'toggle-advance');
+    },
+    computed:{
+      tabNames(){
+        let tabNames = [];
+        for(let tab of this.tabs){
+          tabNames.push(tab.tabName);
+        }
+        return tabNames;
+      }
     },
     methods: {
-        selectTab(selectedTab) {
-            this.tabs.forEach(tab => {
-                clearInterval(this.interval)
-                tab.isActive = (tab.tabName == selectedTab.tabName);
-                this.tabActived = selectedTab.tabName + selectedTab.tabIndex + " is opened"
-            });
+        selectTab(selectedTabIndex) {
+          for(let i=0; i<this.tabs.length;i++){
+            this.tabs[i].isActive = i === selectedTabIndex;
+            if(i === selectedTabIndex){
+              this.tabActivated = this.tabs[i].tabName + i + " is opened";
+            }
+          }
         },
-    },
-    mounted(){
-      this.interval= setInterval(function(){
-        if (this.initialIndex >= this.tabs.length+1) {
-        this.initialIndex = 1;
-        }
-        this.tabs.forEach(tab => {
-              tab.isActive = (tab.tabIndex == this.initialIndex);
-        });
-        this.initialIndex += 1;
-      }.bind(this), 3000)
     }
 }
 </script>

--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -2,11 +2,12 @@
     <div class="tabContainer">
             <ul>
                 <li v-for="(tab,index) in tabs" :key="index" :class="{ 'is-active': tab.isActive }">
-                    <a :href="tab.href" @click="selectTab(tab)">{{ tab.tabName }}</a>
+                    <a :href="tab.href" @click="selectTab(tab)">{{ tab.tabName}}</a>
                 </li>
             </ul>
-
+            <div class="tabDetails">
             <slot></slot>
+            </div>
     </div>
 
 </template>
@@ -15,7 +16,11 @@ export default {
     name: "iv-tabs",
 
     data() {
-        return {tabs: [] };
+        return {
+          tabs: [],
+          tabActived:"Tab 1 is opened",
+          initialIndex: 1,
+          };
     },
     
     created() {
@@ -26,24 +31,46 @@ export default {
     methods: {
         selectTab(selectedTab) {
             this.tabs.forEach(tab => {
+                clearInterval(this.interval)
                 tab.isActive = (tab.tabName == selectedTab.tabName);
+                this.tabActived = selectedTab.tabName + selectedTab.tabIndex + " is opened"
             });
+        },
+    },
+    mounted(){
+      this.interval= setInterval(function(){
+        if (this.initialIndex >= this.tabs.length+1) {
+        this.initialIndex = 1;
         }
+        this.tabs.forEach(tab => {
+              tab.isActive = (tab.tabIndex == this.initialIndex);
+        });
+        this.initialIndex += 1;
+      }.bind(this), 3000)
     }
 }
 </script>
 <style>
 .tabContainer{
   display: block;
-  background: #cce5ff;
-  margin: 5px;
+  position: relative;
+  left:50px;
+}
+.tabContainer .tabDetails{
+  display: block;
+  height: 600px;
+  width: 400px;
+  background-color: powderblue;
+  border-width: 1px;
+  border-style: solid;
+  border-color:black;
+  text-align:center;
 }
 .tabContainer ul {
   list-style-type: none;
   margin: 0;
   padding: 0;
   overflow: hidden;
-  background-color: #2876a3;
 }
 
 .tabContainer li {
@@ -52,15 +79,21 @@ export default {
 
 .tabContainer li a {
   display: block;
+  background-color: #1996df;
   color: rgb(1, 1, 1);
   text-align: center;
   padding: 16px;
   text-decoration: none;
+  border-width: 2px;
+  border-style: solid;
+  border-color:black;
+  margin-right: -2px; 
 }
 
 .tabContainer li a:hover {
-  background-color: #0b4079;
-  border-style: solid;
-  border-color:black;
+  background-color: #0c62be;
+}
+.tabContainer .is-active a{
+  background-color: #0b4188;
 }
 </style>

--- a/src/components/Tabs/Tabs.vue
+++ b/src/components/Tabs/Tabs.vue
@@ -17,7 +17,7 @@ export default {
     data() {
         return {
           tabs: [],
-          tabActived:"Tab 1 is opened",
+          tabActivated:"Tab 1 is opened",
           initialIndex: 0
           };
     },


### PR DESCRIPTION
Restyled the tabs from #31 
![2ba6bcfcdc270da653a5f155f42b7132](https://user-images.githubusercontent.com/40359318/87978113-c758a700-cac7-11ea-943f-07c71aff02f6.png)
To view the example, run `npm run tabtest` in the terminal.
New feature: Automated switching between tabs on opening the page. This will stop once one of the tabs is clicked (selected). 
